### PR TITLE
V0.02: choice between http protocol, cmake fixes, test/example fixes, set/get parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,14 +32,14 @@ target_include_directories(nudock
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nudock>
 )
 
 target_link_libraries(nudock
   PUBLIC
-    nlohmann_json
+    nlohmann_json::nlohmann_json
     nlohmann_json_schema_validator::validator
-    httplib
+    httplib::httplib
 )
 
 # Link the schema dirs to the library
@@ -62,7 +62,13 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/schemas/
   FILES_MATCHING PATTERN "*.json"
 )
 
-install(TARGETS nudock EXPORT nudockTargets)
+install(TARGETS nudock 
+        EXPORT nudockTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 install(EXPORT nudockTargets
   FILE NuDockTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(NuDock VERSION 0.0.1 LANGUAGES CXX)
+project(NuDock VERSION 0.0.2 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(nudock
 target_link_libraries(nudock
   PUBLIC
     nlohmann_json::nlohmann_json
+  PRIVATE
     nlohmann_json_schema_validator::validator
     httplib::httplib
 )

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ To build the `test_server` and `test_client` tests:
 
 ```bash
 cd tests
-# Configure the makefiles
-cmake -B build -DCMAKE_PREFIX_PATH=/path/to/some/local/install/folder/
+# Configure the makefiles.
+cmake -B build -DCMAKE_PREFIX_PATH=/path/to/NuDock/install/folder
 
 # Builds the tests
 cmake --build build
 ```
 
-You can now enter the build directory and first run `./test_server`, and then, in a separate terminal, run `./test_client`. If everything goes well, the client should be able to communicate with the server by sending validating versions against each other firstm and then sending pings & asking for log_likelihoods.
+You can now enter the build directory and first run `./test_server`, and then, in a separate terminal, run `./test_client`. If everything goes well, the client should be able to communicate with the server by sending validating versions against each other first and then setting osc/syst parameters & asking for log_likelihoods.

--- a/cmake/NuDockConfig.cmake.in
+++ b/cmake/NuDockConfig.cmake.in
@@ -6,3 +6,5 @@ find_dependency(Threads)
 find_dependency(nlohmann_json)
 
 include("${CMAKE_CURRENT_LIST_DIR}/NuDockTargets.cmake")
+
+check_required_components(NuDock)

--- a/cmake/httplibConfig.cmake.in
+++ b/cmake/httplibConfig.cmake.in
@@ -1,0 +1,2 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/httplibTargets.cmake")

--- a/cmake/jsonSchemaValidatorConfig.cmake.in
+++ b/cmake/jsonSchemaValidatorConfig.cmake.in
@@ -1,0 +1,2 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/nlohmann_json_schema_validatorTargets.cmake")

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -9,22 +9,20 @@ elseif(EXISTS "${PROJECT_SOURCE_DIR}/externals/json")
     message("Did not find nlohmann_json. We will compile submodule instead.")
     set(JSON_Install ON CACHE INTERNAL "")
     set(JSON_BuildTests OFF CACHE INTERNAL "")
-    add_subdirectory(externals/json EXCLUDE_FROM_ALL)
+    add_subdirectory(externals/json)
     install(TARGETS nlohmann_json 
-            EXPORT nudockTargets
             INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 else()
     message("Did not find nlohmann_json locally. We will fetch it directly from github instead")
 
-    # Adds json directory
+    # Adds json directorj
     include(FetchContent)
     FetchContent_Declare(nlohmann_json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
     set(JSON_Install ON CACHE INTERNAL "")
     set(JSON_BuildTests OFF CACHE INTERNAL "")
     FetchContent_MakeAvailable(nlohmann_json)
     install(TARGETS nlohmann_json 
-            EXPORT nudockTargets
             INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 endif(nlohmann_json_FOUND)
@@ -53,7 +51,7 @@ else()
 
     # Adds cpp-httplib directory
     include(FetchContent)
-    FetchContent_Declare(httplib URL https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.20.0.tar.gz)
+    FetchContent_Declare(httplib URL https://api.github.com/repos/yhirose/cpp-httplib/tarball/v0.20.0)
     # Disable features we don't need
     set(HTTPLIB_USE_BROTLI_IF_AVAILABLE OFF CACHE INTERNAL "")
     set(HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF CACHE INTERNAL "")
@@ -69,8 +67,26 @@ else()
         INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
     install(TARGETS httplib
-        EXPORT nudockTargets
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/
+    )
+
+    # Generate httplibConfig.cmake file
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        ${CMAKE_CURRENT_LIST_DIR}/../cmake/httplibConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/httplibConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/httplib
+    )
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/httplibConfig.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/httplib
+    )
+    install(EXPORT httplibTargets
+        FILE httplibTargets.cmake
+        NAMESPACE httplib::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/httplib
     )
 endif(httplib_FOUND)
 
@@ -87,19 +103,6 @@ elseif(EXISTS "${PROJECT_SOURCE_DIR}/externals/json-schema-validator")
     set(BUILD_EXAMPLES OFF CACHE INTERNAL "")
 
     add_subdirectory(externals/json-schema-validator)
-    set_property(TARGET nlohmann_json_schema_validator APPEND PROPERTY
-        INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
-    )
-    install(TARGETS nlohmann_json_schema_validator
-        EXPORT nudockTargets
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/
-    )
-    install(FILES externals/json-schema-validator/src/nlohmann/json-schema.hpp
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nlohmann
-    )
 else()
     message("Did not find nlohmann_json_schema_validator locally. Use git clone --recurse-submodules to get it or we will fetch it directly from github instead")
 endif(nlohmann_json_schema_validator_FOUND)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,29 +1,38 @@
-
 # Get nlohmann_json
 find_package(nlohmann_json)
 if(nlohmann_json_FOUND)
     message("Found nlohmann_json")
+    if(NOT TARGET nlohmann_json::nlohmann_json)
+        add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
+    endif()
 elseif(EXISTS "${PROJECT_SOURCE_DIR}/externals/json")
     message("Did not find nlohmann_json. We will compile submodule instead.")
-
     set(JSON_Install ON CACHE INTERNAL "")
-    add_subdirectory(externals/json)
-    install(TARGETS nlohmann_json EXPORT nudockTargets)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    add_subdirectory(externals/json EXCLUDE_FROM_ALL)
+    install(TARGETS nlohmann_json 
+            EXPORT nudockTargets
+            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 else()
     message("Did not find nlohmann_json locally. We will fetch it directly from github instead")
 
     # Adds json directory
     include(FetchContent)
-    FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
-    FetchContent_MakeAvailable(json)
+    FetchContent_Declare(nlohmann_json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
     set(JSON_Install ON CACHE INTERNAL "")
-    install(TARGETS nlohmann_json EXPORT nudockTargets)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    FetchContent_MakeAvailable(nlohmann_json)
+    install(TARGETS nlohmann_json 
+            EXPORT nudockTargets
+            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 endif(nlohmann_json_FOUND)
 
 # Get cpp-httplib 
-find_package(cpp-httplib)
-if(cpp-httplib_FOUND)
-    message("Found cpp-httplib")
+find_package(httplib)
+if(httplib_FOUND)
+    message("Found cpp-httplib: ${httplib_VERSION}")
 #elseif(EXISTS "${PROJECT_SOURCE_DIR}/externals/cpp-httplib")
 #    message("Did not find cpp-httplib. We will compile submodule instead.")
 #
@@ -45,14 +54,15 @@ else()
     # Adds cpp-httplib directory
     include(FetchContent)
     FetchContent_Declare(httplib URL https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.20.0.tar.gz)
-    set(HTTPLIB_USE_BROTLI_IF_AVAILABLE OFF)
-    set(HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF)
-    set(HTTPLIB_USE_OPENSSL_IF_AVAILABLE OFF)
-    set(HTTPLIB_USE_ZSTD_IF_AVAILABLE OFF)
-    set(HTTPLIB_REQUIRE_BROTLI OFF)
-    set(HTTPLIB_REQUIRE_OPENSSL OFF)
-    set(HTTPLIB_REQUIRE_ZLIB OFF)
-    set(HTTPLIB_REQUIRE_ZSTD OFF)
+    # Disable features we don't need
+    set(HTTPLIB_USE_BROTLI_IF_AVAILABLE OFF CACHE INTERNAL "")
+    set(HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF CACHE INTERNAL "")
+    set(HTTPLIB_USE_OPENSSL_IF_AVAILABLE OFF CACHE INTERNAL "")
+    set(HTTPLIB_USE_ZSTD_IF_AVAILABLE OFF CACHE INTERNAL "")
+    set(HTTPLIB_REQUIRE_BROTLI OFF CACHE INTERNAL "")
+    set(HTTPLIB_REQUIRE_OPENSSL OFF CACHE INTERNAL "")
+    set(HTTPLIB_REQUIRE_ZLIB OFF CACHE INTERNAL "")
+    set(HTTPLIB_REQUIRE_ZSTD OFF CACHE INTERNAL "")
     FetchContent_MakeAvailable(httplib)
     #add_subdirectory(${cpp-httplib_SOURCE_DIR} ${cpp-httplib_BINARY_DIR} EXCLUDE_FROM_ALL)
     set_property(TARGET httplib APPEND PROPERTY
@@ -60,28 +70,29 @@ else()
     )
     install(TARGETS httplib
         EXPORT nudockTargets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
-endif(cpp-httplib_FOUND)
+endif(httplib_FOUND)
 
+# Get nlohmann_json_schema_validator
 find_package(nlohmann_json_schema_validator)
-
 if(nlohmann_json_schema_validator_FOUND)
     message("Found nlohmann_json_schema_validator")
 elseif(EXISTS "${PROJECT_SOURCE_DIR}/externals/json-schema-validator")
     message("Did not find nlohmann_json_schema_validator. We will compile submodule instead.")  
 
     # Not actually installing it, we only need the headers
-    set(JSON_VALIDATOR_INSTALL OFF)
+    set(JSON_VALIDATOR_INSTALL ON CACHE INTERNAL "")
+    set(BUILD_TESTS OFF CACHE INTERNAL "")
+    set(BUILD_EXAMPLES OFF CACHE INTERNAL "")
 
-    add_subdirectory(externals/json-schema-validator EXCLUDE_FROM_ALL)
+    add_subdirectory(externals/json-schema-validator)
     set_property(TARGET nlohmann_json_schema_validator APPEND PROPERTY
         INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
     )
     install(TARGETS nlohmann_json_schema_validator
         EXPORT nudockTargets
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/

--- a/nudock.cpp
+++ b/nudock.cpp
@@ -12,6 +12,10 @@ NuDock::NuDock(bool _debug,
       m_comm_type(_comm_type), 
       m_port(_port)
 {
+  if (m_default_schemas_location.empty()) {
+    m_default_schemas_location = NUDOCK_SCHEMAS_DIR;
+  }
+
   std::cout << DEBUG() << "Created Nudock instance!" << std::endl;
   std::cout << DEBUG() << "debug  : " << m_debug << std::endl;
   std::cout << DEBUG() << "schemas: " << m_default_schemas_location << std::endl;
@@ -209,8 +213,8 @@ void NuDock::start_server()
     case CommunicationType::UNIX_DOMAIN_SOCKET:
       std::cout << DEBUG() << "Using UNIX domain socket for communication" << std::endl;
       // Clean up the old socket file, if any
-      unlink("/tmp/nudock.sock");
-      m_server->set_address_family(AF_UNIX).listen("/tmp/nudock.sock", m_port);
+      unlink(("/tmp/nudock_" +  std::to_string(m_port) + ".sock").c_str());
+      m_server->set_address_family(AF_UNIX).listen(("/tmp/nudock_" +  std::to_string(m_port) + ".sock").c_str(), m_port);
       break;
     case CommunicationType::LOCALHOST:
       std::cout << DEBUG() << "Using localhost for communication" << std::endl;
@@ -237,7 +241,7 @@ void NuDock::start_client()
   switch (m_comm_type) {
     case CommunicationType::UNIX_DOMAIN_SOCKET:
       std::cout << DEBUG() << "Using UNIX domain socket for communication" << std::endl;
-      m_client = std::make_unique<httplib::Client>("/tmp/nudock.sock", m_port);
+      m_client = std::make_unique<httplib::Client>("/tmp/nudock_" +  std::to_string(m_port) + ".sock");
       m_client->set_address_family(AF_UNIX);
       break;
     case CommunicationType::LOCALHOST:

--- a/nudock.hpp
+++ b/nudock.hpp
@@ -4,14 +4,13 @@
  * @brief A small tool for server-client communication using JSON over HTTP.
  * 
  * @todo: Add debugging that prints out all the json messages into a file.
- * @todo: Refactor to have the http as an option, so we can use this as a library link directly between cross-compiled C++ code.
  * @todo: Sort out the debugging define, should be more descriptive.
  * @todo: Add schema validation layers on the client side too.
  * @todo: The validation should be a compile-time option? Or better, templated. E.g. NuDock<true> for validation, NuDock<false> for no validation.
  * @todo: All functions should have documentation. More comments.
- * @todo: Remove hard-coded localhost and port, make them configurable. If configurable, could even run on a different machine!
  * @todo: Rethink abort(). 
- * @todo: MORE SPEED! Test the Unix Domain Sockets instead, or even shared memory.
+ * @todo: Add versioning to the schemas, so that client and server can negotiate which version to use.
+ * @todo: Add ability to start a container with the server inside (with explicit port number) for easier deployment.
  * 
  * @date 2025-07-01
  * @author Artur Sztuc (a.sztuc@ucl.ac.uk)

--- a/nudock.hpp
+++ b/nudock.hpp
@@ -3,6 +3,7 @@
  * 
  * @brief A small tool for server-client communication using JSON over HTTP.
  * 
+ * @todo: Add debugging that prints out all the json messages into a file.
  * @todo: Refactor to have the http as an option, so we can use this as a library link directly between cross-compiled C++ code.
  * @todo: Sort out the debugging define, should be more descriptive.
  * @todo: Add schema validation layers on the client side too.
@@ -63,23 +64,62 @@ class custom_throwing_error_handler : public nlohmann::json_schema::error_handle
 	}
 };
 
+enum class CommunicationType {
+  UNIX_DOMAIN_SOCKET,
+  LOCALHOST,
+  TCP,
+};
+
 class NuDock
 {
   // Public member functions
   public:
+    /**
+     * @brief NuDock constructor
+     * 
+     * Constructor for NuDock api instance, which can be used as a server or a client.
+     * 
+     * @param _debug Whether to print extra debug messages & do extra validations (not implemented yet)
+     * @param _default_schemas_location Default location of the json schemas. Using NuDock install folder if not specified.
+     * @param _comm_type Communication type between server and client, default is localhost. Unix domain sockets are faster, but only work on the same machine. TCP not implemented.
+     * @param _port Port number for communication, default is 1234. Not important if using unix domain socket.
+     */
     NuDock(bool _debug=true, 
-           const std::string& _default_schemas_location=NUDOCK_SCHEMAS_DIR);
+           const std::string& _default_schemas_location=NUDOCK_SCHEMAS_DIR,
+           const CommunicationType& _comm_type=CommunicationType::LOCALHOST,
+           const int& _port=1234);
 
-    /// @brief Server: responds to requests from the client
+    /** 
+     * @brief Server: responds to requests from the client
+     * 
+     * Blocking function, meaning software execution stops here until the server is stopped.
+     * It starts the server, waits for requests from the client and responds to them.
+     */ 
     void start_server();
 
-    /// @brief Client: sends requests to the server and receives answers
+    /**
+     * @brief Client: sends requests to the server and receives answers
+     * 
+     * It creates httplib::Client instance, and validates the server by sending
+     * the internal software version as a string. Server must be started first.
+     * 
+     * @note MUST be run before sending any requests.
+     * @todo Maybe add start_client() in the send_request() function if client not initialised?
+     */
     void start_client();
 
     /**
-     * @brief Register the server's response handler for a specific request.
+     * @brief Register the server's response function for a specific request name.
      * 
-     * @param _request Request ID name
+     * The handler function must take a json object as input (the request) and
+     * return a json object (the response). 
+     * 
+     * The request name must be unique, e.g. /set_parameters. 
+     * 
+     * The schema path is optional, if not provided it will use the default
+     * schema location + request name + ".schema.json".
+     * 
+     * @param _request Request ID name, including the leading slash, e.g. "/set_parameters"
      * @param _handler_function Function to handle the request, takes json request and returns a json response
      * @param _schema_path Path of the schema file for the request and response validation.
      */
@@ -95,7 +135,7 @@ class NuDock
      * @return json object with the response from the server
      */
     nlohmann::json send_request(const std::string& _request_name,
-                      const nlohmann::json& _message);
+                                const nlohmann::json& _message);
 
   // Private member functions
   private:
@@ -133,6 +173,9 @@ class NuDock
     /// @brief map of request names to their schema validators
     std::unordered_map<std::string, SchemaValidator> m_schema_validator;
 
+    nlohmann::json m_request;
+    nlohmann::json m_response;
+
     /// @brief whether we want to print debug messages
     bool m_debug;
 
@@ -146,4 +189,7 @@ class NuDock
 
     /// @brief Counter for the number of requests sent / processed
     uint64_t m_request_counter;
+
+    CommunicationType m_comm_type;
+    int m_port;
 };

--- a/schemas/log_likelihood_strict.schema.json
+++ b/schemas/log_likelihood_strict.schema.json
@@ -21,7 +21,7 @@
         "sys_pars": {
           "type": "object",
           "patternProperties": {
-            "^[a-zA-Z_][a-zA-Z0-9_]*$": { "type": "number"}
+            "^[a-zA-Z0-9_]+$": { "type": "number"}
           },
           "additionalProperties": false
         }

--- a/schemas/set_parameters.schema.json
+++ b/schemas/set_parameters.schema.json
@@ -21,7 +21,7 @@
         "sys_pars": {
           "type": "object",
           "patternProperties": {
-            "^[a-zA-Z_][a-zA-Z0-9_]*$": { "type": "number"}
+            "^[a-zA-Z0-9_]+$": { "type": "number"}
           },
           "additionalProperties": false
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 
 project(test_nudock LANGUAGES CXX)
 

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -1,27 +1,60 @@
 #include <nudock/nudock.hpp>
+#include <random>
+
+void randomize_parameters(nlohmann::json& _request, std::normal_distribution<double>& dist, std::mt19937& gen)
+{
+    // Randomize osc_pars
+    _request["osc_pars"]["Deltam2_32"] = 0.0025 + dist(gen) * 0.0001;
+    _request["osc_pars"]["Deltam2_21"] = 0.000075 + dist(gen) * 0.00001;
+    _request["osc_pars"]["Theta13"] = 0.15 + dist(gen) * 0.01;
+    _request["osc_pars"]["Theta12"] = 0.55 + dist(gen) * 0.02;
+    _request["osc_pars"]["Theta23"] = 0.5 + dist(gen) * 0.02;
+    _request["osc_pars"]["DeltaCP"] = 0.0 + dist(gen) * 10.0;
+
+    // Randomize sys_pars
+    for (auto& [key, value] : _request["sys_pars"].items()) {
+        _request["sys_pars"][key] = dist(gen);
+    }
+}
 
 int main()
 {
-    NuDock client;
+    // Random gaussian number generator to set the parameters
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::normal_distribution dist(0.0, 1.0);
+    
+    // Create a nudock instance, with debugging enabled and using unix domain sockets
+    NuDock client(true, "", CommunicationType::UNIX_DOMAIN_SOCKET);
     client.start_client();
 
-    json message;
-    message["request"] = "message";
-    message["numb"] = 2.12;
+    // Prepare the set_parameters request json
+    nlohmann::json set_pars_request;
+    set_pars_request["osc_pars"]["Deltam2_32"] = 0.0025;
+    set_pars_request["osc_pars"]["Deltam2_21"] = 0.000075;
+    set_pars_request["osc_pars"]["Theta13"] = 0.15;
+    set_pars_request["osc_pars"]["Theta12"] = 0.55;
+    set_pars_request["osc_pars"]["Theta23"] = 0.5;
+    set_pars_request["osc_pars"]["DeltaCP"] = 0.0;
+    set_pars_request["sys_pars"]["sys1"] = 0.01;
+    set_pars_request["sys_pars"]["sys2"] = 0.02;
 
-    json logl_request;
-    logl_request["osc_pars"]["Deltam2_32"] = 0.002;
-    logl_request["osc_pars"]["Deltam2_21"] = 0.002;
-    logl_request["osc_pars"]["Theta13"] = 0.1;
-    logl_request["osc_pars"]["Theta12"] = 0.1;
-    logl_request["osc_pars"]["Theta23"] = 0.6;
-    logl_request["osc_pars"]["DeltaCP"] = 0.01;
-    logl_request["sys_pars"]["sys1"] = 0.01;
-    logl_request["sys_pars"]["sys2"] = 0.02;
+    // Empty log_likelihood request json
+    nlohmann::json logl_request = "";
 
     while (true) {
-        client.send_request("/ping", "Hello! :)");
-        client.send_request("/log_likelihood", logl_request);
+        // Randomize parameters for each iteration
+        randomize_parameters(set_pars_request, dist, gen);
+
+        // Send set_parameters request
+        client.send_request("/set_parameters", set_pars_request);
+
+        // Send log_likelihood request and print the result
+        nlohmann::json logl_response = client.send_request("/log_likelihood", logl_request);
+        double logl = logl_response["log_likelihood"];
+        std::cout << "Log-likelihood: " << logl << std::endl;
+
+        // Wait for a second before next iteration
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
     return 0;

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -1,71 +1,112 @@
 #include <nudock/nudock.hpp>
 
-json pong(json _request) 
+nlohmann::json pong(const nlohmann::json& _request) 
 {
   std::cout << "Received request from client: " << _request.dump() << std::endl;
-  json response;
+  nlohmann::json response;
   response = "pong";
   return response;
 };
 
-json ping(json _request) 
+class Experiment
 {
-  std::cout << "Received request from client: " << _request.dump() << std::endl;
-  json response;
-  response["message"] = "ping";
-  return response;
-};
-
-json log_likelihood(json _request)
-{
-
-  // nominal values
-  double dm32 = 0.0025;
-  double th13 = 0.15;
-  double th23 = 0.5;
-  double dcp = 0.0;
-
-  double sys1 = 0.01;
-  double sys2 = 0.02;
-
-
-  std::cout << "Received request from client: " << _request.dump() << std::endl;
-
-  std::vector<std::string> required_osc_pars = {"Deltam2_32", "Theta13", "Theta23", "DeltaCP"};
-  for (const std::string& par: required_osc_pars) {
-    if (!_request["osc_pars"].contains(par) || !_request["osc_pars"][par].is_number()) {
-      std::cerr << "Missing or invalid osc_par: " << par << std::endl;
-      throw std::invalid_argument("Missing or invalid osc_par: " + par);
+public:
+  // Set the osc and sys parameters from the request json
+  // This will be used for the fake logl calulation. Will also print the set
+  // parameters to stdout
+  nlohmann::json set_parameters(const nlohmann::json& _request)
+  {
+    for (auto& [key, value] : _request["osc_pars"].items()) {
+      if (!value.is_number()) {
+        std::cerr << "Invalid osc_param value for key: " << key << std::endl;
+        throw std::invalid_argument("Invalid osc_param value for key: " + key);
+      }
+      osc_pars_[key] = value.get<double>();
     }
+
+    for (auto& [key, value] : _request["sys_pars"].items()) {
+      if (!value.is_number()) {
+        std::cerr << "Invalid sys_param value for key: " << key << std::endl;
+        throw std::invalid_argument("Invalid sys_param value for key: " + key);
+      }
+      sys_pars_[key] = value.get<double>();
+    }
+
+    nlohmann::json response;
+    response["status"] = "parameters set";
+    std::cout << "Set osc_pars: ";
+    for (const auto& [key, value] : osc_pars_) {
+      std::cout << key << "=" << value << " ";
+    }
+    std::cout << std::endl;
+    std::cout << "Set sys_pars: ";
+    for (const auto& [key, value] : sys_pars_) {
+      std::cout << key << "=" << value << " ";
+    }
+    std::cout << std::endl;
+    return response;
   }
 
-  for (auto& [key, value] : _request["sys_pars"].items()) {
-    if (!value.is_number()) {
-      std::cerr << "Invalid sys_param value for key: " << key << std::endl;
-      throw std::invalid_argument("Invalid sys_param value for key: " + key);
+  // Simple fake log-likelihood calculation
+  // It will compute a fake log-likelihood based on the internally held parameters
+  nlohmann::json log_likelihood(const nlohmann::json& _request)
+  {
+    // Implementation of log-likelihood calculation using osc_pars_ and sys_pars_
+    nlohmann::json response;
+    response["log_likelihood"] = 0.0; // Placeholder
+
+    // Compute fake log-likelihood based on current parameters
+    double logl = 0.0;
+
+    for (const auto& [key, central_value] : osc_par_central_) {
+      double current_value = osc_pars_.count(key) ? osc_pars_[key] : central_value;
+      logl += std::pow(current_value - central_value, 2);
     }
+
+    // And systeatics, centered at 0 with sigma 1
+    for (const auto& [key, current_value] : sys_pars_) {
+      logl += std::pow(current_value - 0.0, 2);
+    }
+
+
+    response["log_likelihood"] = logl;
+
+    return response;
   }
 
-  double log_prob = 0.0;
-  log_prob += std::pow(_request["osc_pars"]["Deltam2_32"].get<double>() - dm32, 2);
-  log_prob += std::pow(_request["osc_pars"]["Theta13"].get<double>() - th13, 2);
-  log_prob += std::pow(_request["osc_pars"]["Theta23"].get<double>() - th23, 2);
-  log_prob += std::pow(_request["osc_pars"]["DeltaCP"].get<double>() - dcp, 2);
+  private:
+    // Hold the osc parameter name -- value pairs
+    std::map<std::string, double> osc_pars_;
 
-  log_prob += std::pow(_request["sys_pars"]["sys1"].get<double>() - sys1, 2);
-  log_prob += std::pow(_request["sys_pars"]["sys2"].get<double>() - sys2, 2);
+    // Hold the systematic name -- value pairs
+    std::map<std::string, double> sys_pars_;
 
-  json response;
-  response["log_likelihood"] = log_prob;
-
-  return response;
+    // Central values for osc parameters, used for fake logl calculation
+    std::map<std::string, double> osc_par_central_ = {
+      {"Deltam2_32", 0.0025},
+      {"Deltam2_21", 0.000075},
+      {"Theta12", 0.55},
+      {"Theta13", 0.15},
+      {"Theta23", 0.5},
+      {"DeltaCP", 0.0}
+    };
 };
 
 int main()
 {
-  NuDock dock;
+  // Example fake experiment class (e.g. SingleSample/Multi Experiment from NOvA, or some SamplePDFSKBase (or class that contains multiple SamplePDFBase etc) from T2K
+  Experiment experiment;
+
+  // Create a NuDock instance with debugging enabled and using unix domain sockets.
+  // Empty schema location means it will use the default installed location.
+  NuDock dock(true, "", CommunicationType::UNIX_DOMAIN_SOCKET);
+
+  // You can bind to a function that's not a member of any class
   dock.register_response("/ping", std::bind(pong, std::placeholders::_1));
-  dock.register_response("/log_likelihood", std::bind(log_likelihood, std::placeholders::_1));
+
+  // Or bind to member functions of a class instance
+  dock.register_response("/set_parameters", std::bind(&Experiment::set_parameters, &experiment,  std::placeholders::_1));
+  dock.register_response("/log_likelihood", std::bind(&Experiment::log_likelihood, &experiment, std::placeholders::_1));
   dock.start_server();
   return 0;
 }


### PR DESCRIPTION
1. **Version bumped to 0.0.2, server/client versions must match**.
2. You can now choose between http protocols:  `UNIX_DOMAIN_SOCKET`, `LOCALHOST`, `TCP`, and can pass a unique port number (if e.g. running multiple instances on single device)
3. Many cmake fixes, hopefully will make json_validator easier to deal with.
4. The example `server` and `client` implementations in `test` folder are now updated and work. Look at `README.md` for instructions.
5. Updated a list of todos.
6. New schemas for `get_parameters` and `set_parameters` calls, look at `test` folder for example usage.
7. A lot more comments... more incoming.