### PR TITLE
feat: update cmakelists.txt so it could be compiled by CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_FLAGS        "${CMAKE_CXX_FLAGS_INIT} ${CMAKE_CXX_FLAGS} -fPIC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Dependencies
-include(${CMAKE_SOURCE_DIR}/externals/CMakeLists.txt)
+include(${CMAKE_CURRENT_SOURCE_DIR}/externals/CMakeLists.txt)
 
 add_library(nudock SHARED
   nudock.cpp


### PR DESCRIPTION
Changed `CMAKE_SOURCE_DIR` to `CMAKE_CURRENT_SOURCE_DIR` so when MaCh3 CPM compiles nudock it doesn't get confused by the different source directories. 