### PR TITLE
feat: option to set verbosity in nudock

### DIFF
--- a/nudock.hpp
+++ b/nudock.hpp
@@ -36,7 +36,13 @@ using nlohmann::json_schema::json_validator;
 using HandlerFunction = std::function<nlohmann::json(const nlohmann::json&)>;
 
 // Debugging macro to print debug messages with function name and line number
-#define DEBUG() (this->m_debug_prefix + "::" + __func__ + "::L" + std::to_string(__LINE__) + " ")
+#define DEBUG_PREFIX() (this->m_debug_prefix + "::" + __func__ + "::L" + std::to_string(__LINE__) + " ")
+
+// Logging macros that check verbosity level
+#define LOG_DEBUG(msg) if (this->m_verbosity >= VerbosityLevel::DEBUG) std::cout << DEBUG_PREFIX() << msg << std::endl
+#define LOG_INFO(msg) if (this->m_verbosity >= VerbosityLevel::INFO) std::cout << DEBUG_PREFIX() << msg << std::endl
+#define LOG_WARNING(msg) if (this->m_verbosity >= VerbosityLevel::WARNING) std::cerr << DEBUG_PREFIX() << msg << std::endl
+#define LOG_ERROR(msg) if (this->m_verbosity >= VerbosityLevel::ERROR) std::cerr << DEBUG_PREFIX() << msg << std::endl
 
 // Macro to set an error response and stop the server
 #define ERROR_RESPONSE(res, message) \
@@ -69,6 +75,8 @@ enum class CommunicationType {
   TCP,
 };
 
+enum VerbosityLevel { ERROR, WARNING, INFO, DEBUG };
+
 class NuDock
 {
   // Public member functions
@@ -86,7 +94,9 @@ class NuDock
     NuDock(bool _debug=true, 
            const std::string& _default_schemas_location=NUDOCK_SCHEMAS_DIR,
            const CommunicationType& _comm_type=CommunicationType::LOCALHOST,
-           const int& _port=1234);
+           const int& _port=1234,
+           const VerbosityLevel& _verbosity=VerbosityLevel::INFO
+          );
 
     /** 
      * @brief Server: responds to requests from the client
@@ -191,4 +201,7 @@ class NuDock
 
     CommunicationType m_comm_type;
     int m_port;
+
+    /// @brief Verbosity level for logging
+    VerbosityLevel m_verbosity;
 };


### PR DESCRIPTION
Added an option to set the verbosity level of nudock. This is useful during joint fits to prevent nudock spamming the log every time a likelihood is requested. Key changes include:

- Added a `VerbosityLevel` enum for logging verbosity level. The nudock constructor now accepts a verbosity parameter with a default value of `INFO`. 
- Replaced all `std::cout` and `std::cerr` statements with the new logging macros, which only print messages depending on the verbosity. 
- Renamed `DEBUG()` to `DEBUG_PREFIX()` for clearer naming, and used it within the new logging macros. 